### PR TITLE
Simplify createApp.ts by removing ternaries

### DIFF
--- a/packages/react-router/src/17/createApp.tsx
+++ b/packages/react-router/src/17/createApp.tsx
@@ -49,6 +49,11 @@ export const createApp = <MyAppProps extends AppProps = AppProps>(
         .replace(/\/{2,}/g, "/");
       history.replace(initialPath);
 
+      const cleanups = [];
+      if (onRemoteNavigate) {
+        cleanups.push(history.listen((e) => onRemoteNavigate(e.location)));
+      }
+
       return {
         unmount: mountApp({
           ...rest,
@@ -59,9 +64,7 @@ export const createApp = <MyAppProps extends AppProps = AppProps>(
           unmount: () => {
             if (el) ReactDOM.unmountComponentAtNode(el);
           },
-          cleanups: onRemoteNavigate
-            ? [history.listen((e) => onRemoteNavigate(e.location))]
-            : [],
+          cleanups,
           render: ({ appProps, rendered }) => {
             ReactDOM.render(
               <React.StrictMode>

--- a/packages/react-router/src/18/createApp.tsx
+++ b/packages/react-router/src/18/createApp.tsx
@@ -52,6 +52,11 @@ export const createApp = <MyAppProps extends AppProps = AppProps>(
         .replace(/\/{2,}/g, "/");
       history.replace(initialPath);
 
+      const cleanups = [];
+      if (onRemoteNavigate) {
+        cleanups.push(history.listen((e) => onRemoteNavigate(e.location)));
+      }
+
       return {
         unmount: mountApp({
           ...rest,
@@ -63,9 +68,7 @@ export const createApp = <MyAppProps extends AppProps = AppProps>(
             root?.unmount();
             root = null;
           },
-          cleanups: onRemoteNavigate
-            ? [history.listen((e) => onRemoteNavigate(e.location))]
-            : [],
+          cleanups,
           render: ({ appProps, rendered }) => {
             root = root ?? createRoot(el);
             root?.render(

--- a/packages/vue-router/src/createApp.ts
+++ b/packages/vue-router/src/createApp.ts
@@ -82,6 +82,31 @@ export const createApp = (
         ...routerConfig,
       });
 
+      const cleanups = [];
+      if (onRemoteNavigate) {
+        cleanups.push(
+          router.beforeEach((to, from) => {
+            if (from !== START_LOCATION) {
+              // check if the next path (to.path) is inside the mfe (in its routes)
+              const isToAppRoute = routes.find(
+                ({ path }) =>
+                  path.replace(/\/$/, "") === to.path.replace(/\/$/, "")
+              );
+
+              const nextPathname = isToAppRoute
+                ? dedupeSlash([basename, to.path].join("/"))
+                : to.path;
+
+              onRemoteNavigate?.({
+                pathname: nextPathname,
+                hash: to.hash,
+                // TODO search: to.query,
+              });
+            }
+          })
+        );
+      }
+
       return {
         unmount: mountApp({
           ...rest,
@@ -89,29 +114,7 @@ export const createApp = (
           appName,
           isSelfHosted,
           onError,
-          cleanups: onRemoteNavigate
-            ? [
-                router.beforeEach((to, from) => {
-                  if (from !== START_LOCATION) {
-                    // check if the next path (to.path) is inside the mfe (in its routes)
-                    const isToAppRoute = routes.find(
-                      ({ path }) =>
-                        path.replace(/\/$/, "") === to.path.replace(/\/$/, "")
-                    );
-
-                    const nextPathname = isToAppRoute
-                      ? dedupeSlash([basename, to.path].join("/"))
-                      : to.path;
-
-                    onRemoteNavigate?.({
-                      pathname: nextPathname,
-                      hash: to.hash,
-                      // TODO search: to.query,
-                    });
-                  }
-                }),
-              ]
-            : [],
+          cleanups,
           render: ({ appProps, rendered }) => {
             try {
               app = createVueApp(App, { ...appProps, isSelfHosted })


### PR DESCRIPTION
## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached

This PR refactors `createApp` files in `packages/vue-router` and `packages/react-router` (v17 and v18). Unnecessary ternary operators used for conditionally adding items to the `cleanups` array have been replaced with explicit `if` statements. This change enhances code clarity and readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-03f54e99-79d8-4ebf-bc2b-b6bd01dc7039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03f54e99-79d8-4ebf-bc2b-b6bd01dc7039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

